### PR TITLE
add simple alias module

### DIFF
--- a/modules/AliasModule.py
+++ b/modules/AliasModule.py
@@ -1,0 +1,23 @@
+#! /usr/bin/env python
+# coding=utf8
+
+from BotModule import BotModule
+
+class AliasModule(BotModule):
+
+	# define all alias helpers here
+	aliases = {
+		'!intra': '!link intra'
+	}
+
+	def __init__(self):
+		return
+
+	def command(self, nick, cmd, args, type):
+		# check if the alias exists
+		if cmd in aliases:
+			self.sendPublicMessage(aliases[cmd]) # if it exists post the matching alias
+
+	def help(self, nick):
+		self.sendPrivateMessage(nick, "Alias module")
+		return


### PR DESCRIPTION
Einfachste Möglichkeit ein Alias Modul zu haben. Ich habe zunächst versucht direkt das andere Modul aufzurufen. Da das aber alles Modulobjekte sind, die von der Core Klasse verwaltet werden ist das nicht besonders einfach. Da müsste man recht viel umbauen.

**Wichtig** 
Das funktioniert nur, wenn der Bot auch seine eigenen Nachrichten parsed.
